### PR TITLE
Don't use julia submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,6 @@ v2 = 5:-1:1
 repped = R.rep(v1,v2)
 ```
 
-The original Julia vectorized routines offered here do not need to be prefaced:
-
-```julia
-xs = 1:26
-pairwise((x,y)->sqrt(x^2 + y^2), xs)
-```
-
 Although these look like they are calling some outside package from these languages,
 they are bonafide Julia implementations and thus can handle Julia specific issues
 (like using Rational numbers in the meshgrid).
@@ -54,6 +47,13 @@ If you want to export the functions to the main namespace, simply use the comman
 ```julia
 using VectorizedRoutines.R
 rpois(1,[5.2;3.3]) # Same as R.rpois(1,[5.2;3.3])
+
+```
+The original Julia vectorized routines offered here do not need to be prefaced:
+
+```julia
+xs = 1:26
+pairwise((x,y)->sqrt(x^2 + y^2), xs)
 ```
 
 # Current Functions and Macros

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ v2 = 5:-1:1
 repped = R.rep(v1,v2)
 ```
 
+The original Julia vectorized routines offered here does not need to be prefaced:
+
+```julia
+xs = 1:26
+pairwise((x,y)->sqrt(x^2 + y^2), xs)
+```
+
 Although these look like they are calling some outside package from these languages,
 they are bonafide Julia implementations and thus can handle Julia specific issues
 (like using Rational numbers in the meshgrid).
@@ -52,28 +59,28 @@ rpois(1,[5.2;3.3]) # Same as R.rpois(1,[5.2;3.3])
 # Current Functions and Macros
 
 - MATLAB
-  - ngrid
-  - meshgrid
-  - accumarray (fast)
-  - accumarray2 (more functionality)
+  - `ngrid`
+  - `meshgrid`
+  - `accumarray` (fast)
+  - `accumarray2` (more functionality)
   - Compatibility Functions:
-    - disp
-    - strcat
-    - num2str
-    - max
-    - numel
+    - `disp`
+    - `strcat`
+    - `num2str`
+    - `max`
+    - `numel`
 - Python
   - `@vcomp` (*vector comprehension*) macro based on Python's list comprehensions
 with a conditional clause to filter elements in a succinct way, ie: `@vcomp Int[i^2 for i in 1:10] when i % 2 == 0    # Int[4, 16, 36, 64, 100]`
 
 - R
-  - rep
-  - rep!
-  - findinterval
-  - rpois ([fast on vectors](http://codereview.stackexchange.com/questions/134926/benchmarks-of-scientific-programming-languages-r-julia-mathematica-matlab-f/135220#135220))
-  - rpois!
+  - `rep`
+  - `rep!`
+  - `findinterval`
+  - `rpois` ([fast on vectors](http://codereview.stackexchange.com/questions/134926/benchmarks-of-scientific-programming-languages-r-julia-mathematica-matlab-f/135220#135220))
+  - `rpois!``
 
-- Julia
-  - multireshape (a reshape which can produce views to multiple arrays)
-  - pairwise (apply a function to all pairwise combinations of elements from an array)
-  - pairwise!
+- The package also offers Julia-native vectorized routines that are not found in MATLAB, Python or R.
+  - `multireshape` (a reshape which can produce views to multiple arrays)
+  - `pairwise` (apply a function to all pairwise combinations of elements from an array)
+  - `pairwise!``

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ v2 = 5:-1:1
 repped = R.rep(v1,v2)
 ```
 
-The original Julia vectorized routines offered here does not need to be prefaced:
+The original Julia vectorized routines offered here do not need to be prefaced:
 
 ```julia
 xs = 1:26

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ with a conditional clause to filter elements in a succinct way, ie: `@vcomp Int[
   - `rep!`
   - `findinterval`
   - `rpois` ([fast on vectors](http://codereview.stackexchange.com/questions/134926/benchmarks-of-scientific-programming-languages-r-julia-mathematica-matlab-f/135220#135220))
-  - `rpois!``
+  - `rpois!`
 
 - The package also offers Julia-native vectorized routines that are not found in MATLAB, Python or R.
   - `multireshape` (a reshape which can produce views to multiple arrays)
   - `pairwise` (apply a function to all pairwise combinations of elements from an array)
-  - `pairwise!``
+  - `pairwise!`

--- a/src/VectorizedRoutines.jl
+++ b/src/VectorizedRoutines.jl
@@ -8,6 +8,7 @@ include("python.jl")
 include("r.jl")
 include("julia.jl")
 
-export R, Matlab, Julia, Python
+export R, Matlab, Python
+export multireshape, pairwise, pairwise!
 
 end # module

--- a/src/julia.jl
+++ b/src/julia.jl
@@ -1,5 +1,4 @@
-module Julia
-    export multireshape, pairwise, pairwise!
+
 """
 `multireshape(A, dims1, dims2[, ...])`
 
@@ -120,6 +119,4 @@ function pairwise_symmetric_U!(f, a, r::Symmetric, firstval, n)
         j += 1
         i = 1
     end
-end
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ words = ["ant", "akita", "bear", "cow"]
 # Julia
 
 xs = collect(1:26)
-Xs = Julia.multireshape(xs, (2,3), (4,5)) # Array of two matrices, 2×3 and 4×5
+Xs = multireshape(xs, (2,3), (4,5)) # Array of two matrices, 2×3 and 4×5
 # Now, the elements of xs and Xs reference the same memory, no copying.
 xs[26] = 42
 @test Xs[2][4,5] == 42
@@ -33,5 +33,5 @@ Xs[2][3,5] = 100
 # pairwise
 xs = 1:26
 func(x,y) = sqrt(x^2 + y^2)
-@test isapprox(mean(Julia.pairwise(func, xs)), 20.542901932949146)
-@test Julia.pairwise(func, xs, Symmetric) == Symmetric(Julia.pairwise(func, xs))
+@test isapprox(mean(pairwise(func, xs)), 20.542901932949146)
+@test pairwise(func, xs, Symmetric) == Symmetric(pairwise(func, xs))


### PR DESCRIPTION
My suggestion is to allow pairwise routines defined in this package (i.e. not copied from R, Python or Matlab) to be used directly from the package’s main workspace rather than inside a Julia submodule. The two main reasons: 
1. It appears strange to preface something with ‘Julia’ when coding in Julia. In contrast, prefacing something with ‘R’ makes perfect intuitive sense.
2. The other functions are labelled thus because they are copied from functionality elsewhere. The Julia functions on the other hand are introduced de novo here, but having a Julia submodule creates the impression that they are taken from somewhere else. At least that was what I thought when I first encountered this package.