### PR TITLE
Update matlab.jl

### DIFF
--- a/src/matlab.jl
+++ b/src/matlab.jl
@@ -21,7 +21,7 @@ module Matlab
   function ndgrid(vs::AbstractVector{T}...) where {T}
       n = length(vs)
       sz = map(length, vs)
-      out = ntuple(i->Array{T}(sz), n)
+      out = ntuple(i->Array{T}(undef,sz), n)
       s = 1
       for i=1:n
           a = out[i]::Array


### PR DESCRIPTION
It seems the implementation of Matlab.ndgrid with >2 vectors got a bug in initializing the arrays. I went with undef because that was the first one I came across in the docs for Array.